### PR TITLE
Potential fix for code scanning alert no. 6: Clear text transmission of sensitive cookie

### DIFF
--- a/bot.mjs
+++ b/bot.mjs
@@ -223,7 +223,7 @@ app.use(session({
   resave: false,
   saveUninitialized: false,
   cookie: { 
-    secure: false,
+    secure: true,
     maxAge: 60000 * 60 * 24,
     httpOnly: true,
     sameSite: 'lax'


### PR DESCRIPTION
Potential fix for [https://github.com/palidintheonly/Beta-Project/security/code-scanning/6](https://github.com/palidintheonly/Beta-Project/security/code-scanning/6)

To fix the problem, we need to ensure that the session cookie is only transmitted over an HTTPS connection. This can be achieved by setting the `secure` attribute of the session cookie to `true`. This change will ensure that the cookie is only sent over secure HTTPS connections, thereby protecting it from being intercepted by attackers.

The specific change required is to modify the session configuration in the `bot.mjs` file, setting the `secure` attribute of the session cookie to `true`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
